### PR TITLE
Fixed an internal scroll area that could not scroll when the content was not 100%

### DIFF
--- a/src/vue-pull-to.vue
+++ b/src/vue-pull-to.vue
@@ -291,6 +291,7 @@
         }
 
         if (!pe) {
+          event.preventDefault();
           event.stopPropagation();
         }
         this.scrollTo(dist, 0);

--- a/src/vue-pull-to.vue
+++ b/src/vue-pull-to.vue
@@ -290,7 +290,6 @@
           return;
         }
 
-        event.preventDefault();
         if (!pe) {
           event.stopPropagation();
         }


### PR DESCRIPTION
Move `event.preventDefault()` into the judgment of `shouldPassThroughEvent`.

In my case, when the contents of the `vue-pull-to` component do not reach 100% height, the scroll elements inside cannot scroll.